### PR TITLE
Implement initial version of ckeditor5 teching element

### DIFF
--- a/client/components/editor/structure/AddElement/SelectElement.vue
+++ b/client/components/editor/structure/AddElement/SelectElement.vue
@@ -37,6 +37,7 @@ import SelectAssessment from './SelectAssessment';
 
 const TE_TYPES = [
   { type: 'HTML', label: 'Text', icon: 'mdi-format-text' },
+  { type: 'CKEDITOR', label: 'Text (CKEditor)', icon: 'mdi-format-text' },
   { type: 'IMAGE', label: 'Image', icon: 'mdi-image' },
   { type: 'VIDEO', label: 'Video', icon: 'mdi-video' },
   { type: 'BRIGHTCOVE_VIDEO', label: 'Brightcove Video', icon: 'mdi-video' },

--- a/client/components/editor/teaching-elements/CKEditor.vue
+++ b/client/components/editor/teaching-elements/CKEditor.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="te-html">
+    <div v-if="!isFocused && !content">
+      <div class="well text-placeholder">
+        <div class="message">
+          <span class="heading">Text placeholder</span>
+          <span>Click to edit</span>
+        </div>
+      </div>
+    </div>
+    <div v-else>
+      <ckeditor
+        v-if="isFocused"
+        v-model="content"
+        :editor="editor"
+        :config="config"
+        @ready="onEditorReady"
+      >
+      </ckeditor>
+      <div
+        v-else
+        v-html="content"
+        class="editor"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import debounce from 'lodash/debounce';
+import get from 'lodash/get';
+
+import CKEditor from '@ckeditor/ckeditor5-vue';
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+
+export default {
+  name: 'te-html',
+  props: {
+    element: { type: Object, required: true },
+    isFocused: { type: Boolean, default: false }
+  },
+  data() {
+    return {
+      editor: ClassicEditor,
+      content: get(this.element, 'data.content', ''),
+      config: {}
+    };
+  },
+  computed: {
+    hasChanges() {
+      const previousValue = get(this.element, 'data.content', '');
+      return previousValue !== this.content;
+    }
+  },
+  methods: {
+    onEditorReady(editor) {
+      editor.editing.view.focus();
+    },
+    save() {
+      if (!this.hasChanges) return;
+      this.$emit('save', { content: this.content });
+    }
+  },
+  watch: {
+    isFocused(val, oldVal) {
+      if (oldVal && !val) this.save();
+    },
+    content: debounce(function () {
+      this.save();
+    }, 2000)
+  },
+  components: { ckeditor: CKEditor.component }
+};
+</script>
+
+<style lang="scss" scoped>
+.text-placeholder {
+  .message {
+    padding: 9px;
+
+    .heading {
+      font-size: 24px;
+    }
+
+    span {
+      display: block;
+      font-size: 18px;
+    }
+  }
+}
+
+.well {
+  margin-bottom: 0;
+}
+</style>
+
+<style lang="scss">
+.te-html {
+  .editor {
+    min-height: 117px;
+
+    img {
+      vertical-align: initial;
+    }
+  }
+}
+</style>

--- a/client/components/editor/teaching-elements/index.vue
+++ b/client/components/editor/teaching-elements/index.vue
@@ -34,6 +34,7 @@ import TeAudio from './Audio';
 import TeBreak from './PageBreak';
 import TeBrightcoveVideo from './BrightcoveVideo';
 import TeCarousel from './Carousel/Carousel';
+import TeCkeditor from './CKEditor';
 import TeEmbed from './Embed';
 import TeHtml from './Html';
 import TeImage from './Image';
@@ -53,6 +54,7 @@ const TE_TYPES = {
   VIDEO: 'te-video',
   ACCORDION: 'te-accordion',
   CAROUSEL: 'te-carousel',
+  CKEDITOR: 'te-ckeditor',
   MODAL: 'te-modal',
   PDF: 'te-pdf',
   AUDIO: 'te-audio',
@@ -122,6 +124,7 @@ export default {
     TeBreak,
     TeBrightcoveVideo,
     TeCarousel,
+    TeCkeditor,
     TeEmbed,
     TeHtml,
     TeImage,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ckeditor/ckeditor5-build-classic": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-11.2.0.tgz",
+      "integrity": "sha512-wpJf9C8wtnskaFF82BH17AxKITPgXgmlm4ro6QzCd2vYSCSReLkAVL3+OBuSocgxfePAqnrAO6yWjQrYtg8whw=="
+    },
+    "@ckeditor/ckeditor5-vue": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-1.0.0-beta.1.tgz",
+      "integrity": "sha512-CTNyEdofAfmhVomkft6kYEmbh6yRvZMzkvCC4bHZ8LOBHBY7QWkWXP3gbs19SvimUV7PfnsrsDE093aI0SyXqQ=="
+    },
     "@types/geojson": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "prepare": "npm run snyk-protect"
   },
   "dependencies": {
+    "@ckeditor/ckeditor5-build-classic": "^11.2.0",
+    "@ckeditor/ckeditor5-vue": "^1.0.0-beta.1",
     "auto-bind": "^1.2.0",
     "aws-sdk": "^2.178.0",
     "axios": "^0.15.2",
@@ -98,6 +100,7 @@
     "sass-web-fonts": "^2.0.2",
     "save-as": "^0.1.8",
     "sequelize": "^4.22.0",
+    "snyk": "^1.103.4",
     "string-template": "^1.0.0",
     "to-case": "^2.0.0",
     "truncate": "^2.0.0",
@@ -124,8 +127,7 @@
     "vuex-module": "^0.4.0",
     "vuex-router-sync": "^3.0.0",
     "weekstart": "^1.0.0",
-    "yup": "^0.24.1",
-    "snyk": "^1.103.4"
+    "yup": "^0.24.1"
   },
   "devDependencies": {
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
The current version's image insert does not work because no upload adapter is configured, and CKEditor [doesn't support images from url](https://github.com/ckeditor/ckeditor5/issues/555#issuecomment-329089391) by default.

Extending with a plugin is only possible with a separate build, which is the next step, but will be done in a separate PR.