### PR TITLE
Add Jodit editor teaching element

### DIFF
--- a/client/components/editor/structure/AddElement/SelectElement.vue
+++ b/client/components/editor/structure/AddElement/SelectElement.vue
@@ -38,6 +38,7 @@ import SelectAssessment from './SelectAssessment';
 const TE_TYPES = [
   { type: 'HTML', label: 'Text', icon: 'mdi-format-text' },
   { type: 'CKEDITOR', label: 'Text (CKEditor)', icon: 'mdi-format-text' },
+  { type: 'JODIT', label: 'Text (Jodit)', icon: 'mdi-format-text' },
   { type: 'IMAGE', label: 'Image', icon: 'mdi-image' },
   { type: 'VIDEO', label: 'Video', icon: 'mdi-video' },
   { type: 'BRIGHTCOVE_VIDEO', label: 'Brightcove Video', icon: 'mdi-video' },

--- a/client/components/editor/teaching-elements/Jodit.vue
+++ b/client/components/editor/teaching-elements/Jodit.vue
@@ -9,14 +9,12 @@
       </div>
     </div>
     <div v-else>
-      <ckeditor
+      <jodit
         v-if="isFocused"
         v-model="content"
-        :editor="editor"
+        :id="id"
         :config="config"
-        @ready="onEditorReady"
-      >
-      </ckeditor>
+      />
       <div
         v-else
         v-html="content"
@@ -30,20 +28,20 @@
 import debounce from 'lodash/debounce';
 import get from 'lodash/get';
 
-import CKEditor from '@ckeditor/ckeditor5-vue';
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import 'jodit/build/jodit.min.css';
+import Jodit from 'jodit-vue';
 
 export default {
-  name: 'te-ckeditor',
+  name: 'te-jodit',
   props: {
     element: { type: Object, required: true },
-    isFocused: { type: Boolean, default: false }
+    isFocused: { type: Boolean, default: false },
+    id: { type: String, default: 'editor' }
   },
   data() {
     return {
-      editor: ClassicEditor,
       content: get(this.element, 'data.content', ''),
-      config: {}
+      config: { autofocus: true }
     };
   },
   computed: {
@@ -53,9 +51,6 @@ export default {
     }
   },
   methods: {
-    onEditorReady(editor) {
-      editor.editing.view.focus();
-    },
     save() {
       if (!this.hasChanges) return;
       this.$emit('save', { content: this.content });
@@ -69,7 +64,7 @@ export default {
       this.save();
     }, 2000)
   },
-  components: { ckeditor: CKEditor.component }
+  components: { Jodit }
 };
 </script>
 

--- a/client/components/editor/teaching-elements/index.vue
+++ b/client/components/editor/teaching-elements/index.vue
@@ -38,6 +38,7 @@ import TeCkeditor from './CKEditor';
 import TeEmbed from './Embed';
 import TeHtml from './Html';
 import TeImage from './Image';
+import TeJodit from './Jodit';
 import TeModal from './Modal';
 import TePdf from './Pdf';
 import TeTable from './Table';
@@ -55,6 +56,7 @@ const TE_TYPES = {
   ACCORDION: 'te-accordion',
   CAROUSEL: 'te-carousel',
   CKEDITOR: 'te-ckeditor',
+  JODIT: 'te-jodit',
   MODAL: 'te-modal',
   PDF: 'te-pdf',
   AUDIO: 'te-audio',
@@ -128,6 +130,7 @@ export default {
     TeEmbed,
     TeHtml,
     TeImage,
+    TeJodit,
     TeModal,
     TePdf,
     TeTable,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7997,6 +7997,19 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
+    "jodit": {
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/jodit/-/jodit-3.2.31.tgz",
+      "integrity": "sha512-XTazRP+MxrqMm/4wiz/0IugLC9uK0GZqwRT1nFcJ43Wjy0zSXDuJ1vEdqqj2YcAsDasXs5LYsE9VEdrZpoj7+w=="
+    },
+    "jodit-vue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jodit-vue/-/jodit-vue-1.2.3.tgz",
+      "integrity": "sha512-2oQUG/otO2tgyBzyu+yWlM1pJZLlyENgp55lpsWChjQFKh3pnldjiA+4jn7xI1YUlyQbbY7HXLI+sUr4yNwPpg==",
+      "requires": {
+        "jodit": "^3.2.21"
+      }
+    },
     "joi": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "is-iexplorer": "^1.0.0",
     "is-safari": "^1.0.0",
     "is-url": "^1.2.2",
+    "jodit": "3.2.31",
+    "jodit-vue": "^1.2.3",
     "joi": "^10.0.1",
     "jquery": "^3.1.1",
     "jsonwebtoken": "^8.0.0",


### PR DESCRIPTION
The version of `jodit` is hard coded at `3.2.31` until [this issue](https://github.com/WendellAdriel/jodit-vue/issues/4) is resolved. After that, it can be completely removed from `package.json` since it's a dependency of `jodit-vue`.